### PR TITLE
Support invalidating cache

### DIFF
--- a/src/app/modules/admin/admin.module.ts
+++ b/src/app/modules/admin/admin.module.ts
@@ -19,6 +19,7 @@ import { AddResumeEventComponent } from "./resume/addresumeevent/add-resume-even
 import { PreviewResumeEventComponent } from "./resume/previewresumeevent/preview-resume-event.component";
 import { ResumeManagerComponent } from "./resume/resume-manager.component";
 import { UpdateResumeEventComponent } from "./resume/updateresumeevent/update-resume-event.component";
+import { SettingsComponent } from './settings/settings.component';
 
 @NgModule({
     imports: [
@@ -67,6 +68,11 @@ import { UpdateResumeEventComponent } from "./resume/updateresumeevent/update-re
                 path: "author",
                 component: AuthorComponent,
                 canActivate: [AdminGuardService]
+            },
+            {
+                path: "settings",
+                component: SettingsComponent,
+                canActivate: [AdminGuardService]
             }
         ]),
         ReactiveFormsModule,
@@ -84,7 +90,8 @@ import { UpdateResumeEventComponent } from "./resume/updateresumeevent/update-re
         AddResumeEventComponent,
         ResumeManagerComponent,
         PreviewResumeEventComponent,
-        UpdateResumeEventComponent
+        UpdateResumeEventComponent,
+        SettingsComponent
     ],
     providers: [
         AuthorsService,

--- a/src/app/modules/admin/admin.module.ts
+++ b/src/app/modules/admin/admin.module.ts
@@ -19,7 +19,7 @@ import { AddResumeEventComponent } from "./resume/addresumeevent/add-resume-even
 import { PreviewResumeEventComponent } from "./resume/previewresumeevent/preview-resume-event.component";
 import { ResumeManagerComponent } from "./resume/resume-manager.component";
 import { UpdateResumeEventComponent } from "./resume/updateresumeevent/update-resume-event.component";
-import { SettingsComponent } from './settings/settings.component';
+import { SettingsComponent } from "./settings/settings.component";
 
 @NgModule({
     imports: [

--- a/src/app/modules/admin/menu/menu.component.html
+++ b/src/app/modules/admin/menu/menu.component.html
@@ -3,5 +3,6 @@
         <li><a routerLink="/admin/blogs">Blogs</a></li>
         <li><a routerLink="/admin/author">Profile</a></li>
         <li><a routerLink="/admin/resume">Resume</a></li>
+        <li><a routerLink="/admin/settings">Settings</a></li>
     </ul>
 </nav>

--- a/src/app/modules/admin/settings/settings.component.html
+++ b/src/app/modules/admin/settings/settings.component.html
@@ -1,0 +1,9 @@
+<app-admin-menu></app-admin-menu>
+<div class="admin-content">
+    <h1>Settings</h1>
+    <h2>Cache</h2>
+    <p>
+        Configure cache settings.
+    </p>
+    <a class="button" (click)="invalidateCache()">{{invalidateCacheButtonText}}</a>
+</div>

--- a/src/app/modules/admin/settings/settings.component.ts
+++ b/src/app/modules/admin/settings/settings.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from "@angular/core";
+import { CacheService } from "../../../services/cacheservice/cache.service";
+
+@Component({ templateUrl: "./settings.component.html" })
+export class SettingsComponent {
+    invalidateCacheButtonText = "invalidate cache";
+
+    constructor(private _cacheService: CacheService) {
+    }
+
+
+    invalidateCache() {
+        this.invalidateCacheButtonText = "invalidating..";
+        this._cacheService.delete().subscribe(success => {
+            if (success) {
+                this.invalidateCacheButtonText = "cache invalidated";
+                window.setTimeout(() => this.invalidateCacheButtonText = "invalidate cache", 2000);
+            }
+            else {
+                this.invalidateCacheButtonText = "error!";
+                window.setTimeout(() => this.invalidateCacheButtonText = "invalidate cache", 2000);
+            }
+        });
+    }
+}

--- a/src/app/modules/app/app.module.ts
+++ b/src/app/modules/app/app.module.ts
@@ -6,6 +6,7 @@ import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
 import { FooterComponent } from "./footer.component";
 import { HeaderComponent } from "./header.component";
+import { httpInterceptorProviders } from "../../services/httpinterceptors";
 
 @NgModule({
   imports: [
@@ -19,6 +20,9 @@ import { HeaderComponent } from "./header.component";
     HeaderComponent,
     FooterComponent
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
+  providers: [
+    httpInterceptorProviders
+  ]
 })
 export class AppModule { }

--- a/src/app/services/api-service.ts
+++ b/src/app/services/api-service.ts
@@ -11,6 +11,7 @@ export class ApiService {
     createRequestOptions(): Object {
         let headers = new HttpHeaders();
         headers = this.authService.addAuthorizationHeader(headers);
+        headers = headers.set("X-CACHE-ENABLED", "false");
         return { headers: headers };
     }
 

--- a/src/app/services/api-service.ts
+++ b/src/app/services/api-service.ts
@@ -7,6 +7,7 @@ import { throwError } from "rxjs";
 export class ApiService {
     constructor(protected http: HttpClient, protected authService: AuthService) {
     }
+
     handleError(error: HttpErrorResponse) {
         if (error.error instanceof ErrorEvent) {
             console.error("An error occurred:", error.error.message);

--- a/src/app/services/api-service.ts
+++ b/src/app/services/api-service.ts
@@ -7,14 +7,6 @@ import { throwError } from "rxjs";
 export class ApiService {
     constructor(protected http: HttpClient, protected authService: AuthService) {
     }
-
-    createRequestOptions(): Object {
-        let headers = new HttpHeaders();
-        headers = this.authService.addAuthorizationHeader(headers);
-        headers = headers.set("X-CACHE-ENABLED", "false");
-        return { headers: headers };
-    }
-
     handleError(error: HttpErrorResponse) {
         if (error.error instanceof ErrorEvent) {
             console.error("An error occurred:", error.error.message);

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -58,6 +58,11 @@ export class AuthService {
     }
 
     public addAuthorizationHeader(headers: HttpHeaders): HttpHeaders {
-        return headers.set("Authorization", "Bearer " + localStorage.getItem("access_token"));
+        if (localStorage.getItem("access_token")) {
+            return headers.set("Authorization", "Bearer " + localStorage.getItem("access_token"));
+        }
+        else {
+            return headers;
+        }
     }
 }

--- a/src/app/services/authorsservice/authors.service.ts
+++ b/src/app/services/authorsservice/authors.service.ts
@@ -9,18 +9,18 @@ export class AuthorsService extends ApiService {
     private _url: string = environment.apiUri + "api/authors/";
 
     get(): Observable<Author> {
-        return this.http.get<Author>(this._url, this.createRequestOptions());
+        return this.http.get<Author>(this._url);
     }
 
     getWithProfile(): Observable<Author> {
-        return this.http.get<Author>(`${this._url}?includeProfile=true`, this.createRequestOptions());
+        return this.http.get<Author>(`${this._url}?includeProfile=true`);
     }
 
     add(command): Observable<Author> {
-        return this.http.post<Author>(this._url, command, this.createRequestOptions());
+        return this.http.post<Author>(this._url, command);
     }
 
     update(command): Observable<Author> {
-        return this.http.put<Author>(this._url, command, this.createRequestOptions());
+        return this.http.put<Author>(this._url, command);
     }
 }

--- a/src/app/services/blogpostservice/blog-posts.service.ts
+++ b/src/app/services/blogpostservice/blog-posts.service.ts
@@ -22,26 +22,26 @@ export class BlogPostsService extends ApiService {
 
     getAll(tag?): Observable<BlogPostSummary[]> {
         let url = tag ? `${this._url}/?tag=${encodeURIComponent(tag)}` : this._url;
-        return this.http.get<BlogPostSummary[]>(url, this.createRequestOptions());
+        return this.http.get<BlogPostSummary[]>(url);
     }
 
     add(addBlogPostCommand: AddBlogPostCommand, files: FileList): Observable<BlogPostSummary> {
         let formData = this.createFormData(addBlogPostCommand, files);
-        return this.http.post<BlogPostSummary>(this._url, formData, this.createRequestOptions());
+        return this.http.post<BlogPostSummary>(this._url, formData);
     }
 
     getUpdate(id) {
-        return this.http.get<BlogPostUpdate>(`${this._url}/update/${id}`, this.createRequestOptions());
+        return this.http.get<BlogPostUpdate>(`${this._url}/update/${id}`);
     }
 
     update(updateBlogPostCommand: UpdateBlogPostCommand, files: FileList): Observable<BlogPostSummary> {
         let formData = this.createFormData(updateBlogPostCommand, files);
         formData.append("id", updateBlogPostCommand.id.toString());
-        return this.http.put<BlogPostSummary>(`${this._url}/update/`, formData, this.createRequestOptions());
+        return this.http.put<BlogPostSummary>(`${this._url}/update/`, formData);
     }
 
     delete(id) {
-        return this.http.delete(`${this._url}/${id}`, this.createRequestOptions()).pipe(catchError(this.handleError));
+        return this.http.delete(`${this._url}/${id}`).pipe(catchError(this.handleError));
     }
 
     private createFormData(model, files: FileList): FormData {

--- a/src/app/services/cacheservice/cache.service.ts
+++ b/src/app/services/cacheservice/cache.service.ts
@@ -1,0 +1,20 @@
+import { HttpResponse } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { environment } from "../../../environments/environment";
+import { ApiService } from "../api-service";
+
+@Injectable({
+    providedIn: "root"
+})
+export class CacheService extends ApiService {
+    private _url: string = environment.apiUri + "api/cache";
+
+    delete(): Observable<boolean> {
+        return this.http.delete<HttpResponse<Object>>(`${this._url}`, { observe: "response" })
+            .pipe(
+                map(r => r.ok ? true : false)
+            );
+    }
+}

--- a/src/app/services/categoriesservice/categories.service.ts
+++ b/src/app/services/categoriesservice/categories.service.ts
@@ -16,6 +16,6 @@ export class CategoriesService extends ApiService {
     }
 
     getAll(): Observable<Category[]> {
-        return this.http.get<Category[]>(this._url, this.createRequestOptions());
+        return this.http.get<Category[]>(this._url);
     }
 }

--- a/src/app/services/httpinterceptors/admin-interceptor.ts
+++ b/src/app/services/httpinterceptors/admin-interceptor.ts
@@ -14,7 +14,11 @@ export class AdminInterceptor implements HttpInterceptor {
         }
 
         let headers = this._authService.addAuthorizationHeader(req.headers);
-        headers = headers.set("X-CACHE-ENABLED", "false");
+        let loc = location.href;
+
+        if (loc.indexOf("admin") !== -1) {
+            headers = headers.set("X-CACHE-ENABLED", "false");
+        }
 
         let request = req.clone({
             headers: headers

--- a/src/app/services/httpinterceptors/admin-interceptor.ts
+++ b/src/app/services/httpinterceptors/admin-interceptor.ts
@@ -1,0 +1,25 @@
+import { Injectable } from "@angular/core";
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { AuthService } from "../auth.service";
+
+@Injectable()
+export class AdminInterceptor implements HttpInterceptor {
+    constructor(protected _authService: AuthService) {
+    }
+
+    intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+        if (!this._authService.isAuthenticated()) {
+            return next.handle(req);
+        }
+
+        let headers = this._authService.addAuthorizationHeader(req.headers);
+        headers = headers.set("X-CACHE-ENABLED", "false");
+
+        let request = req.clone({
+            headers: headers
+        });
+
+        return next.handle(request);
+    }
+}

--- a/src/app/services/httpinterceptors/index.ts
+++ b/src/app/services/httpinterceptors/index.ts
@@ -1,0 +1,6 @@
+import { HTTP_INTERCEPTORS } from "@angular/common/http";
+import { AdminInterceptor } from "./admin-interceptor";
+
+export const httpInterceptorProviders = [
+    { provide: HTTP_INTERCEPTORS, useClass: AdminInterceptor, multi: true },
+];

--- a/src/app/services/imagesservice/images.service.ts
+++ b/src/app/services/imagesservice/images.service.ts
@@ -11,7 +11,7 @@ export class ImagesService extends ApiService {
     private _url: string = environment.apiUri + "api/images/";
 
     getAll(): Observable<Image[]> {
-        return this.http.get<Image[]>(this._url, this.createRequestOptions());
+        return this.http.get<Image[]>(this._url);
     }
 
     uploadImages(files: FileList): Observable<Image> {
@@ -21,11 +21,11 @@ export class ImagesService extends ApiService {
             formData.append("Files", files[i], files[i].name);
         }
 
-        return this.http.post<Image>(this._url, formData, this.createRequestOptions());
+        return this.http.post<Image>(this._url, formData);
     }
 
     delete(imageId: number) {
-        return this.http.delete(`${this._url}?id=${imageId}`, this.createRequestOptions());
+        return this.http.delete(`${this._url}?id=${imageId}`);
     }
 
     getUri(uriPath: string) {

--- a/src/app/services/resumeservice/resume-events.service.ts
+++ b/src/app/services/resumeservice/resume-events.service.ts
@@ -12,22 +12,22 @@ export class ResumeEventsService extends ApiService {
     private _url: string = environment.apiUri + "api/resumeevents";
 
     getAll(authorId: number): Observable<ResumeEvent[]> {
-        return this.http.get<ResumeEvent[]>(`${this._url}/${authorId}/`, this.createRequestOptions());
+        return this.http.get<ResumeEvent[]>(`${this._url}/${authorId}/`);
     }
 
     get(resumeEventId: number): Observable<ResumeEvent> {
-        return this.http.get<ResumeEvent>(`${this._url}/event/${resumeEventId}/`, this.createRequestOptions());
+        return this.http.get<ResumeEvent>(`${this._url}/event/${resumeEventId}/`);
     }
 
     add(addResumeEventCommand: AddResumeEventCommand): Observable<ResumeEvent> {
-        return this.http.post<ResumeEvent>(this._url, addResumeEventCommand, this.createRequestOptions());
+        return this.http.post<ResumeEvent>(this._url, addResumeEventCommand);
     }
 
     update(updateResumeEventCommand: UpdateResumeEventCommand): Observable<ResumeEvent> {
-        return this.http.put<ResumeEvent>(this._url, updateResumeEventCommand, this.createRequestOptions());
+        return this.http.put<ResumeEvent>(this._url, updateResumeEventCommand);
     }
 
     delete(resumeEventId: number): Observable<Object> {
-        return this.http.delete(`${this._url}/${resumeEventId}/`, this.createRequestOptions());
+        return this.http.delete(`${this._url}/${resumeEventId}/`);
     }
 }

--- a/src/app/services/resumeservice/resume.service.ts
+++ b/src/app/services/resumeservice/resume.service.ts
@@ -11,6 +11,6 @@ export class ResumeService extends ApiService {
     private _url: string = environment.apiUri + "api/resume";
 
     get(authorId: number): Observable<Resume> {
-        return this.http.get<Resume>(`${this._url}/${authorId}/`, this.createRequestOptions());
+        return this.http.get<Resume>(`${this._url}/${authorId}/`);
     }
 }


### PR DESCRIPTION
- HttpInterceptor replaces createRequestOptions() in apiservice.
- Settings page now supports invalidating cache.
- Cache is disabled in admin mode.